### PR TITLE
partytown設定のadsbygoogleをpushに修正

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -17,7 +17,7 @@ export default defineConfig({
     UnoCSS(),
     partytown({
       config: {
-        forward: ['dataLayer.push', 'adsbygoogle'],
+        forward: ['dataLayer.push', 'adsbygoogle.push'],
       },
     }),
   ],


### PR DESCRIPTION
## Issue番号
<!-- ※マージとともクローズの場合は closes をつける -->
#73 

## 対応内容
- partytown 設定の adsbygoogle を push に修正
  - これがずれてたから広告表示されてなかったかも？