### PR TITLE
11月の記事投稿その1 -  フロントエンドカンファレンス沖縄 2023 公開資料・Twitterリンクまとめ

### DIFF
--- a/src/content/posts/2023/2023-11-18-frontend-conf-okinawa-2023.mdx
+++ b/src/content/posts/2023/2023-11-18-frontend-conf-okinawa-2023.mdx
@@ -1,0 +1,161 @@
+---
+title: "フロントエンドカンファレンス沖縄 2023 公開資料・Twitterリンクまとめ"
+description: "フロントエンドカンファレンス沖縄 2023の公開資料、Twitterのリンクまとめ"
+pubDate: "2023-11-18"
+updatedDate: "2023-11-18"
+category: "event"
+tags: ["リンク集", "フロントエンドカンファレンス"]
+---
+
+2023/11/18(土)で開催されたフロントエンドカンファレンス沖縄 2023に関する、現時点での公開資料と X アカウントリンクをまとめました。
+よろしければご活用ください。
+
+import OG from "@/components/OG.astro"
+
+## はじめに
+<OG url="https://frontend-conf.okinawa.jp" />
+
+登壇者名は敬称略させていただいています。
+スライドについては、ご本人がツイートで展開されていたり、スライドサービスにアップロードされているものを記載。
+**Discord の方だけで公開されている方は、勝手に公開しない方がよいかと思いましたので、記載しておりません。**
+
+X アカウントについては、資料に記載されていたり、資料公開のツイートで分かった方のみ記載。
+
+リンクの間違い等ありましたらコメントいただけると助かります🙏
+（Zenn の方でも投稿しているのでそちらのコメントにでも）
+
+ちなみに [Zenn 版](https://zenn.dev/yumemi_inc/articles/2023-11-18-frontend-conf-okinawa-2023)ではスライド埋め込みをしているので、そちらの方がさっと見やすいかもです。
+
+{/* <!-- textlint-disable --> */}
+
+## アーカイブ
+本イベントは YouTube で配信されていて、アーカイブが残るようです。
+<OG url="https://www.youtube.com/watch?v=EAfjjmxkG9A" />
+
+## タイムテーブル
+### 10:10 [ゲストセッション]Figmaプロトタイプ入門〜インタラクションイメージのつくりかた〜
+- 登壇者：中川 小雪[necco]　[@necco_nakagawa](https://x.com/necco_nakagawa)
+
+### 10:30 プライベートプロダクト戦略。Webアプリを起点にしたクロスプラットフォームで大企業が真似できない価値をつくる
+- 登壇者：榊原昌彦　[@rdlabo](https://x.com/rdlabo)
+
+<OG url="https://speakerdeck.com/rdlabo/private-product-frontend" />
+
+### 11:00 Bunで変わるフロントエンドの世界
+- 登壇者：tada　[@taketada323](https://x.com/taketada323)
+
+### 11:15 ビジネスサイドの要望をかなえながらVue2からVue3にアップグレードした話
+- 登壇者：てつえもん　[@tetsuemon_oki](https://x.com/tetsuemon_oki)
+
+### 11:25 デザインシステムはじめの一歩
+- 登壇者：yuuri
+
+### 11:35 [ゲストセッション]リッチなアニメーションを手軽に実装！ Lottieアニメーションの基本と活用事例
+- 登壇者：田口 冬菜[necco]　[@fuyuna_design](https://x.com/fuyuna_design)
+
+### 11:50 デザインシステムの技術選定・設計の勘所 2023
+- 登壇者：takanorip[Ubie]　[@takanoripe](https://x.com/takanoripe)
+
+<OG url="https://www.figma.com/proto/uSIoSaF1Psg3lBkSHPEARx/2023%E5%B9%B4%E7%89%88-%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3%E3%82%B7%E3%82%B9%E3%83%86%E3%83%A0-%E6%8A%80%E8%A1%93%E9%81%B8%E5%AE%9A%E3%81%AE%E5%8B%98%E6%89%80---%E3%83%95%E3%83%AD%E3%83%B3%E3%83%88%E3%82%A8%E3%83%B3%E3%83%89%E3%82%AB%E3%83%B3%E3%83%95%E3%82%A1%E3%83%AC%E3%83%B3%E3%82%B9%E6%B2%96%E7%B8%84?type=design&node-id=1-2&t=atIWRqOeGvEKt6q2-1&scaling=contain&page-id=0%3A1" />
+
+### 12:20 フロントエンドエンジニアも知っておきたい HTTP/3 で変わること
+- 登壇者：吉田あひる[スターフェスティバル]　[@strtyuu](https://x.com/strtyuu)
+
+<OG url="https://speakerdeck.com/yahiru/3-debian-warukoto" />
+
+### 12:30 ReactメインのチームにNext.jsを導入した道のり
+- 登壇者：ペンギン丸　[@pengin_engineer](https://x.com/pengin_engineer)
+
+### 13:40 [スポンサートーク]フロントエンドで物流現場をサポートする
+- 登壇者： 原田遼[CBcloud]
+
+### 13:50 [スポンサートーク]業種の枠を超えて、D2C企画担当者自身がChatGPTを駆使して診断サイトを制作
+- 登壇者：古畑なみ[ホライズンテクノロジー]
+
+### 13:55 [スポンサートーク]日経のエンジニア組織とフロントエンド開発
+- 登壇者：
+	- Ryoma Abe(araya)[日本経済新聞社]　[@arayaryoma](https://x.com/arayaryoma)
+	- Shinobu Hayashi(Shinyaigeek)[日本経済新聞社]　[@Shinyaigeek](https://x.com/Shinyaigeek)
+
+<OG url="https://speakerdeck.com/nikkei_engineer_recruiting/frontend-okinawa" />
+
+### 14:05 イベント設計におけるフロントエンドな考え方、その魅力
+- 登壇者：こぎそ　[@kgsi](https://x.com/kgsi)
+
+<OG url="https://speakerdeck.com/kgsi/front-end-thinking-in-event-planning" />
+
+### 14:15 進化したWeb技術でPWAをネイティブアプリに近づける
+- 登壇者：Yuhei_FUJITA　[@Yuhei_FUJITA](https://x.com/Yuhei_FUJITA)
+
+<OG url="https://speakerdeck.com/yuhei_fujita/frontend-conf-2023" />
+
+### 14:45 フロントエンジニアの戦闘力をエンパワメントするheadlessCMSという選択肢
+- 登壇者：Takuya Takeda　[@taketaku123](https://x.com/taketaku123)
+
+### 15:00 GraphQLクライアントの技術選定
+- 登壇者：早瀬和輝[BuySell]　[@KazukiHayase](https://x.com/KazukiHayase)
+
+<OG url="https://speakerdeck.com/kazukihayase/graphqlkuraiantonoji-shu-xuan-ding-2023dong" />
+
+### 15:30 アクセシビリティを理解するとフロントエンドのテストが楽になる！
+- 登壇者：しょうた[スターフェスティバル]　[@nano72mkn](https://x.com/nano72mkn)
+
+<OG url="https://speakerdeck.com/nano72mkn/akusesibiriteiwoli-jie-surutohurontoendonotesutogale-ninaru" />
+
+### 15:40 SupabaseとSvelteKitで作るバックエンドレスなサーバーレスWebサイト
+- 登壇者：清家史郎[Fusic]　[@seike460](https://x.com/seike460)
+
+<OG url="https://speakerdeck.com/seike460/creating-with-supabase-and-sveltekit-backend-less-serverless-websites" />
+
+### 16:15 なぜコピペで利用するコンポーネント集を採用するのか？
+- 登壇者：mottox2　[@mottox2](https://x.com/mottox2)
+
+<OG url="https://speakerdeck.com/mottox2/nasekohiheteshi-ukonhonentoji-woli-yong-surunoka" />
+
+### 16:25 Expo RouterはExpo導入の決め手となるか
+- 登壇者：どぎー[ゆめみ]　[@Kaito_Dogi](https://x.com/Kaito_Dogi)
+
+<OG url="https://speakerdeck.com/doggy/expo-router-ha-expo-dao-ru-nojue-meshou-tonaruka-hurontoendokanhuarensuchong-nawa-2023-at-kaito-dogi" />
+
+### 16:55 Now and Next generation of CSS Cascading Model
+- 登壇者：araya[日本経済新聞社]　[@arayaryoma](https://x.com/arayaryoma)
+
+<OG url="https://www.docswell.com/s/araya/51JEY8-fec-okinawa-2023" />
+
+### 17:15 LT: React Native for web導入失敗記
+- 登壇者：sori　[@sori_ja](https://x.com/sori_ja)
+
+### 17:20 LT: Figma Widgetを自作して、デザイナーとエンジニアのコラボレーション強化を図る
+- 登壇者：Toya Yamanishi　[@toyamani_twt_jp](https://x.com/toyamani_twt_jp)
+
+関連
+<OG url="https://www.figma.com/community/widget/1301142159170473003/tag-note" />
+
+### 17:25 LT: Web フロントエンドにおける副作用との向き合い方
+- 登壇者：Shinobu Hayashi(Shinyaigeek)[日本経済新聞社]　[@Shinyaigeek](https://x.com/Shinyaigeek)
+
+<OG url="https://speakerdeck.com/shinyaigeek/managing-side-effect-in-frontend-development" />
+
+### 17:35 LT: フロントエンドエンジニアが「Webサービスアプリ化して」と言われた時にWebViewでリリースした話
+- 登壇者：tada　[@taketada323](https://x.com/taketada323)
+
+### 17:40 LT: 2023年のゼロランタイムCSS in JSを考える
+- 登壇者：Oyu[DMM]　[@yud0uhu](https://x.com/yud0uhu)
+
+<OG url="https://speakerdeck.com/yud0uhu/2023nian-no-zerorantaimucss-in-js-wokao-eru" />
+
+### 17:45 LT: ユーザー登録とログインフォームにautocomplete属性を使いましょう
+- 登壇者：Ivanova Marina[ゆめみ]　[@qcapy_frontend](https://x.com/qcapy_frontend)
+
+<OG url="https://speakerdeck.com/ivanova1991/yuzadeng-lu-toroguinhuomuniautocompleteshu-xing-woshi-imasiyou" />
+
+### 17:50 LT: Astro3.0+TranstionAPIでイケてるサイトを爆速開発していく feat. React
+- 登壇者：pluto[Cyberagent]　[@pluto_04](https://x.com/pluto_04)
+
+---
+
+今回は同僚が登壇していたこともあって、オンライン参加で雄姿を見守っておりました。
+配信動画も残るようですので、気になったセッションはまた見直してみようと思いますー。
+（他の作業しながら流し見していた部分もあり、しょうもないツイートがノイズになっていたらすみません🙏）
+
+{/* <!-- textlint-enable --> */}


### PR DESCRIPTION
## Issue番号
<!-- ※マージとともクローズの場合は closes をつける -->
closes #128 

## 対応内容
記事投稿： フロントエンドカンファレンス沖縄 2023 公開資料・Twitterリンクまとめ
