### PR TITLE
FEConf 沖縄2023、JSConf JP 2023記事に資料を追加（11/20分）

### DIFF
--- a/generated/ogp/2023.json
+++ b/generated/ogp/2023.json
@@ -719,6 +719,12 @@
     "image": "https://files.speakerdeck.com/presentations/a7b580a07aef4799b3526b4b725a6db4/slide_0.jpg?27876565",
     "favicon": "https://www.google.com/s2/favicons?sz=256&domain=https://speakerdeck.com"
   },
+  "https://speakerdeck.com/iuchimasatoshi/reactmeinnotimuninext-dot-jswodao-ru-sitadao-nori": {
+    "title": "ReactメインのチームにNext.jsを導入した道のり",
+    "description": "2023年11月18日(土) に登壇したフロントエンドカンファレンスの登壇資料となります。\n\nhttps://frontend-conf.okinawa.jp/",
+    "image": "https://files.speakerdeck.com/presentations/4f3047546898480187697f7e2a4d39fc/slide_0.jpg?27864384",
+    "favicon": "https://www.google.com/s2/favicons?sz=256&domain=https://speakerdeck.com"
+  },
   "https://jsconfjp-slide.pages.dev/": {
     "title": "",
     "description": "",

--- a/generated/ogp/2023.json
+++ b/generated/ogp/2023.json
@@ -916,5 +916,23 @@
     "description": "power-assert esm loader. Latest version: 0.1.0, last published: 8 hours ago. Start using @power-assert/esm in your project by running `npm i @power-assert/esm`. There are no other projects in the npm registry using @power-assert/esm.",
     "image": "https://static-production.npmjs.com/338e4905a2684ca96e08c7780fc68412.png",
     "favicon": "https://www.google.com/s2/favicons?sz=256&domain=https://www.npmjs.com"
+  },
+  "https://www.docswell.com/s/hireroo/5987RP-2023-11-19-JSConfJP-confidence-boundaries-of-values": {
+    "title": "TypeScriptで型定義を信頼しすぎず「信頼境界線」を設置した話 | ドクセル",
+    "description": "ドクセルはスライドやPDFをかんたんに共有できるサイトです",
+    "image": "https://img.docswell.com/cover/972GLYZR7R.jpg",
+    "favicon": "https://www.google.com/s2/favicons?sz=256&domain=https://www.docswell.com"
+  },
+  "https://docs.google.com/presentation/d/1hjs2J4fScWcs42oJ11F9uv1iuSnb_25TEZxyJo6UlLU/edit": {
+    "title": "JSConf2023_vf_en_public",
+    "description": "TEARING DOWN 'BRICK-BREAK-ANYWHERE' JOURNEY INTO THE UNCHARTED TERRITORIES OF DOM SCRIPTING",
+    "image": "https://lh7-us.googleusercontent.com/docs/AHkbwyJTw0G2RqjAJ1tchOWeBtsYMV9YGcmpJ25M882Y3wd4m8kVmHw6pi0M1ROLWGXuHRv4fBOzLSRnlZEPmj38cvuXtnDWS8oeEu9fZk-kPDizM_I=w1200-h630-p",
+    "favicon": "https://www.google.com/s2/favicons?sz=256&domain=https://docs.google.com"
+  },
+  "https://speakerdeck.com/poteboy/kuma-uinokoremadetokorekara": {
+    "title": "Kuma UIのこれまでとこれから",
+    "description": "Discover the journey of how someone with no prior OSS experience built this zero-runtime UI component library, the story behind its creation, its evolution, and the future vision for Kuma UI.",
+    "image": "https://files.speakerdeck.com/presentations/c93aca578731436597ed59aee7d49090/slide_0.jpg?27880732",
+    "favicon": "https://www.google.com/s2/favicons?sz=256&domain=https://speakerdeck.com"
   }
 }

--- a/src/content/posts/2023/2023-11-18-frontend-conf-okinawa-2023.mdx
+++ b/src/content/posts/2023/2023-11-18-frontend-conf-okinawa-2023.mdx
@@ -66,6 +66,8 @@ X アカウントについては、資料に記載されていたり、資料公
 ### 12:30 ReactメインのチームにNext.jsを導入した道のり
 - 登壇者：ペンギン丸　[@pengin_engineer](https://x.com/pengin_engineer)
 
+<OG url="https://speakerdeck.com/iuchimasatoshi/reactmeinnotimuninext-dot-jswodao-ru-sitadao-nori" />
+
 ### 13:40 [スポンサートーク]フロントエンドで物流現場をサポートする
 - 登壇者： 原田遼[CBcloud]
 

--- a/src/content/posts/2023/2023-11-19-jsconf-jp-2023.mdx
+++ b/src/content/posts/2023/2023-11-19-jsconf-jp-2023.mdx
@@ -94,6 +94,8 @@ x アカウントについては、以下のように確認できたものを記
 
 - 登壇者：Himenon[ハイヤールー]　[@himenoglyph](https://x.com/himenoglyph)
 
+<OG url="https://www.docswell.com/s/hireroo/5987RP-2023-11-19-JSConfJP-confidence-boundaries-of-values" />
+
 ### A 14:10-14:40 Beyond the Web of Today
 
 - 登壇者：Kenneth Rohde Christiansen[Intel]　[@kennethrohde](https://x.com/kennethrohde)
@@ -170,6 +172,8 @@ x アカウントについては、以下のように確認できたものを記
 ### C 16:00-16:30 ゲーム「webページ崩し」の仕組み〜あなたの知らないDOMスクリプティングの世界〜
 
 - 登壇者：canalun (Kanaru Sato)[Tech Touch]　[@i_am_canalun](https://x.com/i_am_canalun)
+
+<OG url="https://docs.google.com/presentation/d/1hjs2J4fScWcs42oJ11F9uv1iuSnb_25TEZxyJo6UlLU/edit" />
 
 webページ崩しを遊べるデモサイト
 <OG url="https://canalun-company-2.deno.dev/guest_rooms/brickBlockAnywhere" />
@@ -259,7 +263,6 @@ webページ崩しを遊べるデモサイト
 - 登壇者：池原大然[Okta Japan]　[@Neri78](https://x.com/Neri78)
 
 ### A 19:00-19:10 Second System Syndrome - the tale of power-assert
-
 - 登壇者：和田卓人　[@t_wada](https://x.com/t_wada)
 
 <OG url="https://speakerdeck.com/twada/second-system-syndrome-a-tale-of-power-assert" />
@@ -269,12 +272,12 @@ webページ崩しを遊べるデモサイト
 <OG url="https://www.npmjs.com/package/swc-plugin-power-assert" />
 
 ### A 19:10-19:20 Hope is postponed disappointment
-
 - 登壇者：Luca Mugnaini[楽天]　[@luca_mug](https://x.com/luca_mug)
 
 ### A 19:20-19:30 The Past and Future of Kuma UI
-
 - 登壇者：poteboy[THECOO]　[@_poteboy_](https://x.com/_poteboy_)
+
+<OG url="https://speakerdeck.com/poteboy/kuma-uinokoremadetokorekara" />
 
 ### A 19:30-19:40 JavaScript なしで動作するモダンなコードの書き方
 


### PR DESCRIPTION
## Issue番号
<!-- ※マージとともクローズの場合は closes をつける -->
#128 #131 

## 対応内容
記事更新
- FEConf 沖縄2023：12:30 ReactメインのチームにNext.jsを導入した道のり
- JSConf JP 2023：
  - C 13:30-14:00 TypeScriptで型定義を信頼しすぎず「信頼境界線」を設置した話
  - C 16:00-16:30 ゲーム「webページ崩し」の仕組み〜あなたの知らないDOMスクリプティングの世界〜
  - A 19:20-19:30 The Past and Future of Kuma UI
