### PR TITLE
FEConf 北海道 2024記事で取り消し線で認識されていた箇所の修正

### DIFF
--- a/src/content/posts/2024/2024-08-25-frontend-conf-hokkaido-2024.mdx
+++ b/src/content/posts/2024/2024-08-25-frontend-conf-hokkaido-2024.mdx
@@ -76,7 +76,7 @@ X アカウントについては、fortee や資料に記載されていたり�
 
 <OG url="https://speakerdeck.com/ryo_manba/5fen-defen-karu-react-aria-no-liang-itokorokorekaranatokoro" />
 
-### 11:50 - B - 小規模サイトでも使えるVite ~HTMLコーディングをよりスマートに~
+### 11:50 - B - 小規模サイトでも使えるVite ～HTMLコーディングをよりスマートに～
 - 登壇者：長谷川広武[HAMWORKS]　[@h2ham](https://x.com/h2ham)
 
 <OG url="https://speakerdeck.com/h2ham/hurontoendokanhuarensubei-hai-dao-2024-xiao-gui-mo-saitodemoshi-eruvite-htmlkodeinguwoyorisumatoni-chang-gu-chuan-guang-wu-hamu" />


### PR DESCRIPTION
## Issue番号
<!-- ※マージとともクローズの場合は closes をつける -->
closes #173 

## 対応内容
- 見出しで取り消し線認識されていた箇所を修正