### PR TITLE
gtagスクリプトにis:inlineをつけて、GA4計測できるようにした

### DIFF
--- a/src/components/GA.astro
+++ b/src/components/GA.astro
@@ -5,9 +5,10 @@ const GOOGLE_ANALYTICS_TAG = import.meta.env.GOOGLE_ANALYTICS_TAG;
 <!-- Google tag (gtag.js) -->
 <script
   type="text/partytown"
+  is:inline
   src=`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_TAG}`
 ></script>
-<script type="text/partytown" define:vars={{ GOOGLE_ANALYTICS_TAG }}>
+<script type="text/partytown" is:inline define:vars={{ GOOGLE_ANALYTICS_TAG }}>
   window.dataLayer = window.dataLayer || [];
   function gtag() {
     // eslint-disable-next-line no-undef


### PR DESCRIPTION
## Issue番号
<!-- ※マージとともクローズの場合は closes をつける -->
#181 

## 対応内容
- GA4 計測できなかった問題の修正