### PR TITLE
JSConf JP 2024 の記事修正 - 資料を追加

### DIFF
--- a/generated/ogp/2024.json
+++ b/generated/ogp/2024.json
@@ -114,6 +114,12 @@
       "image": "https://files.speakerdeck.com/presentations/689e73c19d764a84b739597b2059ecd6/slide_0.jpg?32735779",
       "favicon": "https://www.google.com/s2/favicons?sz=256&domain=https://speakerdeck.com"
     },
+    "https://speakerdeck.com/kintotechdev/kurumanosabusukuwo-next-dot-jsdenei-zhi-hua-sitajing-yan-tosono1nian-hou": {
+      "title": "クルマのサブスクを Next.jsで内製化した経験とその1年後",
+      "description": "KINTOテクノロジーズ株式会社では2023年に「車のサブスクKINTO」の大規模な内製化（刷新）を完了しました。 この際、ユーザー体験はもちろん開発体験の向上も視野に入れつつNext.jsを中心として技術選定を行いました。 このセッションでは、車のサブスクを担うシステムの大規模リプレースの中でどのよう&hellip;",
+      "image": "https://files.speakerdeck.com/presentations/c6e3276cc2e6402e9a52d7197848d480/slide_0.jpg?32781560",
+      "favicon": "https://www.google.com/s2/favicons?sz=256&domain=https://speakerdeck.com"
+    },
     "https://speakerdeck.com/l1lhu1hu1/sutetupubaisutetupudejin-meruyahoo-zhi-hui-dai-nohurontoendoriakitekuto": {
       "title": "ステップバイステップで進めるYahoo!知恵袋のフロントエンドリアーキテクト",
       "description": "",

--- a/src/content/posts/2024/2024-11-24-jsconf-jp-2024.mdx
+++ b/src/content/posts/2024/2024-11-24-jsconf-jp-2024.mdx
@@ -2,7 +2,7 @@
 title: "JSConf JP 2024 公開資料・Xアカウントリンクまとめ"
 description: "JSConf JP 2024の公開資料、Xアカウントのリンクまとめ"
 pubDate: "2024-11-24"
-updatedDate: "2024-11-26"
+updatedDate: "2024-11-28"
 category: "event"
 tags: ["リンク集", "JSConf JP"]
 ---
@@ -36,6 +36,8 @@ x アカウントについては、以下のように確認できたものを記
 - 2024/11/26
   - 登壇者名を修正：C 15:30-16:00 ESLint のカスタムルールで治安維持活動をする
   - 本人記事を追加：B 15:30-16:00 Modular Monolith Monorepo
+- 2024/11/28
+  - スライドを追加：D 15:30-16:00 クルマのサブスクサービスを Next.js で内製化した経験とその1年後
 
 ## アーカイブ
 
@@ -287,6 +289,8 @@ x アカウントについては、以下のように確認できたものを記
 - 登壇社：KINTOテクノロジーズ
   - N Okawara　[@nori_okwr](https://x.com/nori_okwr)
   - ahomu　[@ahomu](https://x.com/ahomu)
+
+<OG url="https://speakerdeck.com/kintotechdev/kurumanosabusukuwo-next-dot-jsdenei-zhi-hua-sitajing-yan-tosono1nian-hou" />
 
 ### A 16:00-16:30 Moving Three.js from WebGL to WebGPU
 


### PR DESCRIPTION
## Issue番号
<!-- ※マージとともクローズの場合は closes をつける -->
#190 

## 対応内容
- JSConf JP 2024：資料追加 - D 15:30-16:00 クルマのサブスクサービスを Next.js で内製化した経験とその1年後